### PR TITLE
Fixed JUnit git repository URI and NAME

### DIFF
--- a/chapter-8/timeline.swing.application/src/main/java/book/twju/timeline/swing/application/Application.java
+++ b/chapter-8/timeline.swing.application/src/main/java/book/twju/timeline/swing/application/Application.java
@@ -16,8 +16,8 @@ import book.twju.timeline.util.FileStorageStructure;
 public class Application {
 
   private static final File BASE_DIRECTORY = new File( System.getProperty( "user.home" ) );
-  private static final String URI = "git@github.com:junit-team/junit.git";
-  private static final String REPOSITORY_NAME = "junit";
+  private static final String URI = "https://github.com/junit-team/junit4.git";
+  private static final String REPOSITORY_NAME = "junit4";
   
   public static void main( String[] args ) {
     Locale.setDefault( Locale.ENGLISH );

--- a/chapter-8/timeline.swt.application/src/main/java/book/twju/timeline/swt/application/Application.java
+++ b/chapter-8/timeline.swt.application/src/main/java/book/twju/timeline/swt/application/Application.java
@@ -15,8 +15,8 @@ import book.twju.timeline.util.FileStorageStructure;
 public class Application {
   
   private static final File BASE_DIRECTORY = new File( System.getProperty( "user.home" ) );
-  private static final String URI = "git@github.com:junit-team/junit.git";
-  private static final String REPOSITORY_NAME = "junit";
+  private static final String URI = "https://github.com/junit-team/junit4.git";
+  private static final String REPOSITORY_NAME = "junit4";
 
   public static void main( String[] args ) {
     Locale.setDefault( Locale.ENGLISH );

--- a/chapter-8/timeline.tabris/src/main/java/book/twju/timeline/tabris/TimelineEntryPoint.java
+++ b/chapter-8/timeline.tabris/src/main/java/book/twju/timeline/tabris/TimelineEntryPoint.java
@@ -17,8 +17,8 @@ import book.twju.timeline.util.FileStorageStructure;
 public class TimelineEntryPoint implements EntryPoint {
 
   private static final File BASE_DIRECTORY = new File( System.getProperty( "user.home" ) );
-  private static final String URI = "git@github.com:junit-team/junit.git";
-  private static final String REPOSITORY_NAME = "junit";
+  private static final String URI = "https://github.com/junit-team/junit4.git";
+  private static final String REPOSITORY_NAME = "junit4";
   
   private final StorageDirectoryProvider storageDirectoryProvider;
 


### PR DESCRIPTION
From what I understand, the JUnit git repository has been split into
two: junit4 and junit5, thus the URI in the applications must be updated
accordingly.

Moreover, using git@ requires authentication, while the https URI does
not.
